### PR TITLE
Adds (sort) 'options' feature and new tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,48 +47,30 @@ console.log(output)
 
 ```
 
-## Optional parameters
+## Options
 
-### Custom sort function
-
-You can pass a custom sort function as the second argument. This function is passed to the Javascript <code>sort</code> function, that sorts in alphabetical order by default. The custom function should return zero, a negative or positive value:
+You can pass an options object as the second argument, the supported options are the following:
 
 ```js
-var reverseAlphabeticalSort = function (a, b) {
-  return a < b
+var options = {
+  ignoreArrayAtKeys: [ // Don't sort the Array at the specified keys, if any.
+    'b'
+  ],
+  ignoreObjectAtKeys: [ // Don't sort the Object at the specified keys, if any.
+    'a'
+  ],
+  // Custom sort function, passed to the Javascript sort() function.
+  // If omitted, elements are sorted alphabetically.
+  compareFunction: function (a, b) {
+    return a < b
+  }
 }
-
-var object = {
-  a: {
-    a: 0,
-    c: ['c', 'a', 'b'],
-    b: 0
-  },
-  c: 0,
-  b: 0
-}
-
-var output = sort(object, reverseAlphabeticalSort)
-
-console.log(output)
-
-// {
-//   c: 0,
-//   b: 0,
-//   a: {
-//     c: ['c', 'b', 'a'],
-//     b: 0,
-//     a: 0
-//   }
-// }
-
 ```
 
-### Options
-
-You can pass an options object as the third argument, the supported options are the following:
+#### Example: <code>ignoreArrayAtKeys</code> and <code>ignoreObjectAtKeys</code>
 
 ```js
+
 var options = {
   ignoreArrayAtKeys: [ // Don't sort the Array at the specified keys, if any.
     'b'
@@ -109,7 +91,7 @@ var input = {
   d: ['a', 'c', 'b']
 }
 
-var output = sort(object, null, options)
+var output = sort(object, options)
 
 console.log(output)
 
@@ -122,6 +104,45 @@ console.log(output)
 //   },
 //   b: ['a', 'c', 'b'],
 //   d: ['a', 'b', 'c']
+// }
+
+```
+
+#### Example: <code>compareFunction</code>
+
+You can pass a custom sort function as <code>compareFunction</code>. This function is passed to Javascript <code>[sort()](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)</code>, that sorts in alphabetical order by default. The custom function should return zero, a negative or positive value:
+
+```js
+var reverseAlphabeticalSort = function (a, b) {
+  return a < b
+}
+
+var options = {
+  compareFunction: reverseAlphabeticalSort
+}
+
+var object = {
+  a: {
+    a: 0,
+    c: ['c', 'a', 'b'],
+    b: 0
+  },
+  c: 0,
+  b: 0
+}
+
+var output = sort(object, options)
+
+console.log(output)
+
+// {
+//   c: 0,
+//   b: 0,
+//   a: {
+//     c: ['c', 'b', 'a'],
+//     b: 0,
+//     a: 0
+//   }
 // }
 
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,48 @@ console.log(output)
 
 ```
 
+### Options
+
+You can pass an options object as the third argument, the supported options are the following:
+
+```js
+var options = {
+  ignoreArrayAtKeys: [ // Don't sort the Array at the specified keys, if any.
+    'b'
+  ],
+  ignoreObjectAtKeys: [ // Don't sort the Object at the specified keys, if any.
+    'a'
+  ]
+}
+
+var input = {
+  a: { // This Object will not be sorted.
+    a: 'a',
+    b: 'b',
+    c: 'c',
+    d: ['a', 'c', 'b']
+  },
+  b: ['a', 'c', 'b'], // This Array will not be sorted.
+  d: ['a', 'c', 'b']
+}
+
+var output = sort(object, null, options)
+
+console.log(output)
+
+// {
+//   a: {
+//     a: 'a',
+//     b: 'b',
+//     c: 'c',
+//     d: ['a', 'c', 'b']
+//   },
+//   b: ['a', 'c', 'b'],
+//   d: ['a', 'b', 'c']
+// }
+
+```
+
 ## License
 
 MIT © [Kiko Beats](http://www.kikobeats.com)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,43 @@ console.log(output)
 
 ```
 
+## Optional parameters
+
+### Custom sort function
+
+You can pass a custom sort function as the second argument. This function is passed to the Javascript <code>sort</code> function, that sorts in alphabetical order by default. The custom function should return zero, a negative or positive value:
+
+```js
+var reverseAlphabeticalSort = function (a, b) {
+  return a < b
+}
+
+var object = {
+  a: {
+    a: 0,
+    c: ['c', 'a', 'b'],
+    b: 0
+  },
+  c: 0,
+  b: 0
+}
+
+var output = sort(object, reverseAlphabeticalSort)
+
+console.log(output)
+
+// {
+//   c: 0,
+//   b: 0,
+//   a: {
+//     c: ['c', 'b', 'a'],
+//     b: 0,
+//     a: 0
+//   }
+// }
+
+```
+
 ## License
 
 MIT © [Kiko Beats](http://www.kikobeats.com)

--- a/index.js
+++ b/index.js
@@ -9,16 +9,19 @@ function inArray (value, arr) {
   return arr.indexOf(value) > -1
 }
 
-function sortObjectKeys (obj, compare, options) {
+function sortObjectKeys (obj, compare) {
   return sortKeys(obj, compare)
 }
 
-function sortArray (arr, compare) {
-  return arr.slice().sort(compare)
+function sortArray (arr, options) {
+  const compareFunction = options && options.compareFunction
+
+  return arr.slice().sort(compareFunction)
 }
 
-function sortObject (obj, compare, options) {
-  var result = sortObjectKeys(obj, compare)
+function sortObject (obj, options) {
+  const compareFunction = options && options.compareFunction
+  var result = sortObjectKeys(obj, compareFunction)
 
   Object.keys(obj).forEach(function (key) {
     var current = result[key]
@@ -26,14 +29,14 @@ function sortObject (obj, compare, options) {
 
     if (type === 'object') {
       if (!options || !inArray(key, options.ignoreObjectAtKeys)) {
-        result[key] = sortObject(current, compare, options)
+        result[key] = sortObject(current, options)
       }
       return
     }
 
     if (type === 'array') {
       if (!options || !inArray(key, options.ignoreArrayAtKeys)) {
-        result[key] = sortArray(current, compare, options)
+        result[key] = sortArray(current, options)
       }
       return
     }
@@ -42,10 +45,10 @@ function sortObject (obj, compare, options) {
   return result
 }
 
-function sort (something, compareFn, opts) {
+function sort (something, opts) {
   var type = kindOf(something)
 
-  if (sort[type]) return sort[type](something, compareFn, opts)
+  if (sort[type]) return sort[type](something, opts)
   return something
 }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,13 @@
 var sortKeys = require('sort-keys')
 var kindOf = require('kind-of')
 
-function sortObjectKeys (obj, compare) {
+function inArray (value, arr) {
+  if (!arr || kindOf(arr) !== 'array') return false
+
+  return arr.indexOf(value) > -1
+}
+
+function sortObjectKeys (obj, compare, options) {
   return sortKeys(obj, compare)
 }
 
@@ -11,7 +17,7 @@ function sortArray (arr, compare) {
   return arr.slice().sort(compare)
 }
 
-function sortObject (obj, compare) {
+function sortObject (obj, compare, options) {
   var result = sortObjectKeys(obj, compare)
 
   Object.keys(obj).forEach(function (key) {
@@ -19,12 +25,16 @@ function sortObject (obj, compare) {
     var type = kindOf(current)
 
     if (type === 'object') {
-      result[key] = sortObject(current, compare)
+      if (!options || !inArray(key, options.ignoreObjectAtKeys)) {
+        result[key] = sortObject(current, compare, options)
+      }
       return
     }
 
     if (type === 'array') {
-      result[key] = sortArray(current)
+      if (!options || !inArray(key, options.ignoreArrayAtKeys)) {
+        result[key] = sortArray(current, compare, options)
+      }
       return
     }
   })
@@ -32,9 +42,10 @@ function sortObject (obj, compare) {
   return result
 }
 
-function sort (something, compareFn) {
+function sort (something, compareFn, opts) {
   var type = kindOf(something)
-  if (sort[type]) return sort[type](something, compareFn)
+
+  if (sort[type]) return sort[type](something, compareFn, opts)
   return something
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -68,3 +68,34 @@ test('sort object', (t) => {
   }
   t.deepEqual(sort(object), sorted)
 })
+
+test('sort object > compareFn', (t) => {
+  const input = {
+    a: {
+      a: 0,
+      c: ['c', 'a', 'b'],
+      b: 0
+    },
+    c: 0,
+    b: 0
+  }
+
+  const expectedResult = {
+    c: 0,
+    b: 0,
+    a: {
+      c: ['c', 'b', 'a'],
+      b: 0,
+      a: 0
+    }
+  }
+
+  // Sort in reverse alphabetical order (instead of the default alphabetical order).
+  const result = sort(input, (a, b) => a < b)
+
+  t.deepEqual(result, expectedResult)
+
+  // Check the ordering of the keys.
+  t.deepEqual(Object.keys(result), Object.keys(expectedResult))
+  t.deepEqual(Object.keys(result.a), Object.keys(expectedResult.a))
+})

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,14 @@
 var sort = require('..')
 var test = require('ava')
 
+test('sort returns non-array/non-object as is', (t) => {
+  const nonSortables = ['foo', null, 34]
+
+  nonSortables.forEach(
+    (nonSortable) => t.deepEqual(sort(nonSortable), nonSortable)
+  )
+})
+
 test('sort array', (t) => {
   var arr = ['foo', 'bar']
   t.deepEqual(

--- a/test/test.js
+++ b/test/test.js
@@ -77,7 +77,7 @@ test('sort object', (t) => {
   t.deepEqual(sort(object), sorted)
 })
 
-test('sort object > compareFn', (t) => {
+test('sort object > options.compareFunction', (t) => {
   const input = {
     a: {
       a: 0,
@@ -98,8 +98,12 @@ test('sort object > compareFn', (t) => {
     }
   }
 
+  const options = {
+    compareFunction: (a, b) => a < b
+  }
+
   // Sort in reverse alphabetical order (instead of the default alphabetical order).
-  const result = sort(input, (a, b) => a < b)
+  const result = sort(input, options)
 
   t.deepEqual(result, expectedResult)
 
@@ -125,7 +129,7 @@ test('sort object > options.ignoreObjectAtKeys', (t) => {
     ]
   }
 
-  const result = sort(input, null, options)
+  const result = sort(input, options)
 
   const expectedResult = {
     a: {
@@ -160,7 +164,7 @@ test('sort object > options.ignoreArrayAtKeys', (t) => {
     ]
   }
 
-  const result = sort(input, null, options)
+  const result = sort(input, options)
 
   const expectedResult = {
     a: {

--- a/test/test.js
+++ b/test/test.js
@@ -107,3 +107,73 @@ test('sort object > compareFn', (t) => {
   t.deepEqual(Object.keys(result), Object.keys(expectedResult))
   t.deepEqual(Object.keys(result.a), Object.keys(expectedResult.a))
 })
+
+test('sort object > options.ignoreObjectAtKeys', (t) => {
+  const input = {
+    a: {
+      b: ['a', 'c', 'b'],
+      c: {
+        d: [true, {f: 'g'}]
+      },
+      d: 'e'
+    }
+  }
+
+  const options = {
+    ignoreObjectAtKeys: [
+      'c'
+    ]
+  }
+
+  const result = sort(input, null, options)
+
+  const expectedResult = {
+    a: {
+      b: ['a', 'b', 'c'],
+      c: {
+        d: [true, {f: 'g'}]
+      },
+      d: 'e'
+    }
+  }
+
+  t.deepEqual(result, expectedResult)
+
+  // Check the ordering of the keys.
+  t.deepEqual(Object.keys(result.a), Object.keys(expectedResult.a))
+})
+
+test('sort object > options.ignoreArrayAtKeys', (t) => {
+  const input = {
+    a: {
+      c: {
+        d: [true, {f: 'g'}]
+      },
+      b: ['a', 'c', 'b'],
+      d: 'e'
+    }
+  }
+
+  const options = {
+    ignoreArrayAtKeys: [
+      'b'
+    ]
+  }
+
+  const result = sort(input, null, options)
+
+  const expectedResult = {
+    a: {
+      b: ['a', 'c', 'b'],
+      c: {
+        d: [{f: 'g'}, true]
+      },
+      d: 'e'
+    }
+  }
+
+  t.deepEqual(result, expectedResult)
+
+  // Check the ordering of the keys.
+  t.deepEqual(Object.keys(result.a), Object.keys(expectedResult.a))
+})


### PR DESCRIPTION
The following commits improve the existing code, docs and tests:
- test/docs: add test and docs for the custom sort function parameter
- test: add non-array/non-object test

This one adds the new feature:
- feat: add 'options' support with a new third, optional parameter

See: #2 